### PR TITLE
fix: 解决代码过长时会超出界面的问题

### DIFF
--- a/src/views/cellRoom/midjourney/index.vue
+++ b/src/views/cellRoom/midjourney/index.vue
@@ -581,7 +581,7 @@ function getTimeDate(newDate: string, oldDate: string) {
               fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
             />
           </div>
-          <div>
+          <div style="display: flex; flex-direction: column; max-width: 100%;">
             <n-ellipsis min-width-140px>
               {{ item.createTime }}
             </n-ellipsis>

--- a/src/views/cellRoom/newBing/index.vue
+++ b/src/views/cellRoom/newBing/index.vue
@@ -269,7 +269,7 @@ async function changData(talkdata: any, done = false) {
               fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
             />
           </div>
-          <div>
+          <div style="display: flex; flex-direction: column; max-width: 100%;">
             <n-ellipsis min-width-140px mb-5>
               {{ item.createTime }}
             </n-ellipsis>

--- a/src/views/cellRoom/openaiChat/index.vue
+++ b/src/views/cellRoom/openaiChat/index.vue
@@ -234,7 +234,7 @@ async function changData(talkdata: any, done = false) {
               fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
             />
           </div>
-          <div>
+          <div style="display: flex; flex-direction: column; max-width: 100%;">
             <n-ellipsis min-width-140px mb-5>
               {{ item.createTime }}
             </n-ellipsis>

--- a/src/views/cellRoom/openaiChatWeb/index.vue
+++ b/src/views/cellRoom/openaiChatWeb/index.vue
@@ -235,7 +235,7 @@ async function changData(talkdata: any, done = false) {
               fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
             />
           </div>
-          <div>
+          <div style="display: flex; flex-direction: column; max-width: 100%;">
             <n-ellipsis min-width-140px mb-5>
               {{ item.createTime }}
             </n-ellipsis>

--- a/src/views/cellRoom/openaiImg/index.vue
+++ b/src/views/cellRoom/openaiImg/index.vue
@@ -236,7 +236,7 @@ async function changData(talkdata: any, done = false) {
               fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
             />
           </div>
-          <div>
+          <div style="display: flex; flex-direction: column; max-width: 100%;">
             <n-ellipsis min-width-140px mb-5>
               {{ item.createTime }}
             </n-ellipsis>

--- a/src/views/cellRoom/wyqfChat/index.vue
+++ b/src/views/cellRoom/wyqfChat/index.vue
@@ -234,7 +234,7 @@ async function changData(talkdata: any, done = false) {
               fallback-src="https://07akioni.oss-cn-beijing.aliyuncs.com/07akioni.jpeg"
             />
           </div>
-          <div>
+          <div style="display: flex; flex-direction: column; max-width: 100%;">
             <n-ellipsis min-width-140px mb-5>
               {{ item.createTime }}
             </n-ellipsis>


### PR DESCRIPTION
当markdown预览器中的代码段过长时，会超出页面且不显示横向滚动条。
复现方法：新建聊天室，输入“用一行代码实现快速排序”。
解决：给父容器设置flex属性，且最大宽度为100%